### PR TITLE
Add combat controls overlay and restart flow

### DIFF
--- a/Fighter.js
+++ b/Fighter.js
@@ -1,6 +1,6 @@
 // js/game/entities/Fighter.js
 
-import { GRAVITY, GROUND_Y, GAME_WIDTH, FIGHTER_STATE, MAX_HEALTH, ATTACK_COOLDOWN_MS, DEBUG_OPTIONS } from './config.js';
+import { GRAVITY, GROUND_Y, GAME_WIDTH, FIGHTER_STATE, MAX_HEALTH, ATTACK_COOLDOWN_MS, DEBUG_OPTIONS, ATTACK_DAMAGE } from './config.js';
 import { getAsset } from './assets.js';
 import { FIGHTERS_DATA } from './fightersdata.js'; // Importer les données des combattants
 
@@ -10,7 +10,7 @@ const DEFAULT_ATTACK_HITBOX_CONFIG = {
         heightFactor: 0.3,
         offsetXFactor: 0.55,
         offsetYFactor: 0.45,
-        damage: 6,
+        damage: ATTACK_DAMAGE.LIGHT,
         startFrame: 0,
         endFrame: Number.POSITIVE_INFINITY,
     },
@@ -19,7 +19,7 @@ const DEFAULT_ATTACK_HITBOX_CONFIG = {
         heightFactor: 0.35,
         offsetXFactor: 0.52,
         offsetYFactor: 0.38,
-        damage: 10,
+        damage: ATTACK_DAMAGE.MEDIUM,
         startFrame: 0,
         endFrame: Number.POSITIVE_INFINITY,
     },
@@ -28,7 +28,7 @@ const DEFAULT_ATTACK_HITBOX_CONFIG = {
         heightFactor: 0.45,
         offsetXFactor: 0.5,
         offsetYFactor: 0.3,
-        damage: 14,
+        damage: ATTACK_DAMAGE.HEAVY,
         startFrame: 0,
         endFrame: Number.POSITIVE_INFINITY,
     },

--- a/config.js
+++ b/config.js
@@ -10,6 +10,13 @@ export const MAX_HEALTH = 100;
 export const ATTACK_COOLDOWN_MS = 300; // Temps de récupération après une attaque
 export const INPUT_BUFFER_TIME_MS = 150; // Temps pour buffer les inputs de combos
 
+// Valeurs de dégâts de base pour chaque type d'attaque
+export const ATTACK_DAMAGE = {
+    LIGHT: 6,
+    MEDIUM: 10,
+    HEAVY: 14,
+};
+
 // Configuration des touches pour les deux joueurs
 export const CONTROLS = {
     PLAYER1: {

--- a/game.css
+++ b/game.css
@@ -18,6 +18,7 @@
     margin: 20px auto;
     border-radius: 8px; /* Léger arrondi des coins */
     z-index: 1; /* S'assure qu'il est en dessous du scanline body */
+    flex-shrink: 0;
 }
 
 #gameCanvas {
@@ -27,6 +28,149 @@
     max-width: 100%;
     /* Effet léger de grain ou de bruit sur le canvas pour le rendre moins "propre" */
     filter: saturate(1.1) contrast(1.1);
+}
+
+.game-layout {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+    width: 100%;
+    max-width: 1600px;
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+.controls-panel {
+    width: min(100%, 640px);
+    background: linear-gradient(160deg, rgba(15, 15, 15, 0.85) 0%, rgba(48, 48, 48, 0.75) 100%);
+    border: 3px solid var(--border-color);
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow:
+        0 12px 25px rgba(0, 0, 0, 0.6),
+        inset 0 0 12px rgba(255, 255, 255, 0.05);
+    text-align: left;
+    backdrop-filter: blur(2px);
+}
+
+.controls-panel h2 {
+    font-family: var(--font-display);
+    font-size: clamp(1.4rem, 2.5vw, 2rem);
+    margin-bottom: 16px;
+    color: var(--primary-color);
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}
+
+.controls-panel__columns {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
+.controls-panel__column {
+    flex: 1 1 240px;
+    background: rgba(0, 0, 0, 0.35);
+    border: 2px solid rgba(255, 255, 255, 0.05);
+    border-radius: 8px;
+    padding: 16px;
+    box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.4);
+}
+
+.controls-panel__column h3 {
+    font-family: var(--font-display);
+    font-size: 1.1rem;
+    margin-bottom: 12px;
+    color: var(--accent-color-2);
+    text-transform: uppercase;
+}
+
+.controls-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.controls-list li {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+
+.keycap {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 62px;
+    padding: 6px 12px;
+    background: rgba(0, 0, 0, 0.75);
+    border: 2px solid var(--accent-color-2);
+    border-radius: 6px;
+    box-shadow: inset 0 0 8px rgba(30, 144, 255, 0.4);
+    font-family: var(--font-display);
+    font-size: 0.85rem;
+    letter-spacing: 1px;
+    text-align: center;
+}
+
+.action {
+    flex: 1;
+    font-size: 1rem;
+    letter-spacing: 0.5px;
+}
+
+.damage {
+    margin-left: 8px;
+    color: var(--accent-color-1);
+    font-family: var(--font-display);
+    font-size: 0.9rem;
+}
+
+.controls-buttons {
+    margin-top: 24px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+}
+
+.control-button {
+    flex: 1 1 220px;
+    display: inline-block;
+    text-align: center;
+    padding: 14px 18px;
+    background: var(--accent-color-2);
+    color: var(--text-light);
+    text-decoration: none;
+    border-radius: 8px;
+    border: 3px solid var(--border-color);
+    appearance: none;
+    font-family: var(--font-display);
+    font-size: 1rem;
+    letter-spacing: 1px;
+    box-shadow: 4px 4px 0 var(--secondary-color);
+    transition: transform 0.15s ease, background-color 0.2s ease, box-shadow 0.15s ease;
+    cursor: pointer;
+}
+
+.control-button:hover {
+    transform: translateY(-3px);
+    background-color: var(--accent-color-1);
+    box-shadow: 6px 6px 0 var(--secondary-color);
+}
+
+.control-button:active {
+    transform: translateY(0);
+    box-shadow: 2px 2px 0 var(--secondary-color);
+}
+
+.control-button--primary {
+    background: var(--accent-color-1);
+}
+
+.control-button--primary:hover {
+    background: #ff5c1c;
 }
 
 /* HUD Styling - Design Arcade Classique */
@@ -173,5 +317,22 @@
 
     .timer {
         padding: 8px 16px;
+    }
+}
+
+@media (min-width: 1100px) {
+    .game-layout {
+        flex-direction: row;
+        align-items: flex-start;
+        justify-content: center;
+    }
+
+    #game-container {
+        margin: 20px;
+    }
+
+    .controls-panel {
+        position: sticky;
+        top: 40px;
     }
 }

--- a/game.html
+++ b/game.html
@@ -8,32 +8,68 @@
     <link rel="stylesheet" href="game.css">
 </head>
 <body>
-    <div id="game-container">
-        <div id="hud">
-            <div class="player-hud player-1-hud">
-                <div class="health-bar-container">
-                    <div class="health-bar player-1-health"></div>
+    <main class="game-layout">
+        <div id="game-container">
+            <div id="hud">
+                <div class="player-hud player-1-hud">
+                    <div class="health-bar-container">
+                        <div class="health-bar player-1-health"></div>
+                    </div>
+                    <div class="character-portrait player-1-portrait"></div>
+                    <div class="energy-bar-container">
+                        <div class="energy-bar player-1-energy"></div>
+                    </div>
                 </div>
-                <div class="character-portrait player-1-portrait"></div>
-                <div class="energy-bar-container">
-                    <div class="energy-bar player-1-energy"></div>
+
+                <div class="timer">99</div>
+                <div class="player-hud player-2-hud">
+                    <div class="health-bar-container">
+                        <div class="health-bar player-2-health"></div>
+                    </div>
+                    <div class="character-portrait player-2-portrait"></div>
+                    <div class="energy-bar-container">
+                        <div class="energy-bar player-2-energy"></div>
+                    </div>
                 </div>
             </div>
-            
-            <div class="timer">99</div>
-            <div class="player-hud player-2-hud">
-                <div class="health-bar-container">
-                    <div class="health-bar player-2-health"></div>
-                </div>
-                <div class="character-portrait player-2-portrait"></div>
-                <div class="energy-bar-container">
-                    <div class="energy-bar player-2-energy"></div>
-                </div>
-            </div>
+
+            <canvas id="gameCanvas"></canvas>
         </div>
-        
-        <canvas id="gameCanvas"></canvas>
-    </div>
+
+        <aside class="controls-panel">
+            <h2>Commandes</h2>
+            <div class="controls-panel__columns">
+                <div class="controls-panel__column">
+                    <h3>Joueur 1</h3>
+                    <ul class="controls-list">
+                        <li><span class="keycap">A / D</span><span class="action">Se déplacer</span></li>
+                        <li><span class="keycap">W</span><span class="action">Sauter</span></li>
+                        <li><span class="keycap">J</span><span class="action">Attaque légère <span class="damage" data-attack-damage="light"></span></span></li>
+                        <li><span class="keycap">K</span><span class="action">Attaque moyenne <span class="damage" data-attack-damage="medium"></span></span></li>
+                        <li><span class="keycap">L</span><span class="action">Attaque lourde <span class="damage" data-attack-damage="heavy"></span></span></li>
+                        <li><span class="keycap">Q</span><span class="action">Roulade défensive</span></li>
+                        <li><span class="keycap">E</span><span class="action">Dash offensif</span></li>
+                    </ul>
+                </div>
+                <div class="controls-panel__column">
+                    <h3>Joueur 2</h3>
+                    <ul class="controls-list">
+                        <li><span class="keycap">&larr; / &rarr;</span><span class="action">Se déplacer</span></li>
+                        <li><span class="keycap">&uarr;</span><span class="action">Sauter</span></li>
+                        <li><span class="keycap">7 (Num)</span><span class="action">Attaque légère <span class="damage" data-attack-damage="light"></span></span></li>
+                        <li><span class="keycap">8 (Num)</span><span class="action">Attaque moyenne <span class="damage" data-attack-damage="medium"></span></span></li>
+                        <li><span class="keycap">9 (Num)</span><span class="action">Attaque lourde <span class="damage" data-attack-damage="heavy"></span></span></li>
+                        <li><span class="keycap">4 (Num)</span><span class="action">Roulade défensive</span></li>
+                        <li><span class="keycap">5 (Num)</span><span class="action">Dash offensif</span></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="controls-buttons">
+                <a href="index.html" class="control-button">Accueil</a>
+                <button type="button" id="restart-button" class="control-button control-button--primary">Relancer le round</button>
+            </div>
+        </aside>
+    </main>
 
     <script type="module" src="game.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- centralize damage values for light, medium, and heavy attacks in the shared config and fighter logic
- hook the game loop to populate attack damage hints and add a manual restart flow that clears pending round timers
- add an in-game controls panel with styling plus buttons to return home or restart the round

## Testing
- No automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c9825433108323a4c4dd96b68c3621